### PR TITLE
Fix FastMCP compatibility and pin dependency versions

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,7 +13,7 @@ load_dotenv()
 # Initialize MCP server
 mcp = FastMCP(
     name="Secureframe MCP Server",
-    description="Read-only access to Secureframe compliance platform data"
+    instructions="Read-only access to Secureframe compliance platform data"
 )
 
 # Configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,10 +23,10 @@ classifiers = [
     "Topic :: Office/Business",
 ]
 dependencies = [
-    "fastmcp>=2.0.0",
-    "httpx>=0.25.0",
-    "pydantic>=2.0.0",
-    "python-dotenv>=1.0.0",
+    "fastmcp~=2.7.1",
+    "httpx~=0.28.1",
+    "pydantic~=2.10.5",
+    "python-dotenv~=1.0.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-fastmcp>=2.0.0
-httpx>=0.25.0
-pydantic>=2.0.0
-python-dotenv>=1.0.0
+fastmcp~=2.7.1
+httpx~=0.28.1
+pydantic~=2.10.5
+python-dotenv~=1.0.0


### PR DESCRIPTION
Fixes TypeError in FastMCP initialization by replacing the deprecated 'description' parameter with 'instructions' (required in FastMCP 2.7.1+). Also pins dependency versions using compatible release operator (~=) to allow patch updates while preventing breaking changes from minor/major version bumps.