### PR TITLE
Bump python-dotenv to ~=1.1.0 to satisfy fastmcp dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
     "fastmcp~=2.7.1",
     "httpx~=0.28.1",
     "pydantic~=2.10.5",
-    "python-dotenv~=1.0.0",
+    "python-dotenv~=1.1.0",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 fastmcp~=2.7.1
 httpx~=0.28.1
 pydantic~=2.10.5
-python-dotenv~=1.0.0
+python-dotenv~=1.1.0


### PR DESCRIPTION
fastmcp 2.7.1 requires python-dotenv>=1.1.0, but we had pinned to ~=1.0.0 which caused a dependency conflict during installation.