### PR TITLE
Deprecate repository: point to hosted Secureframe MCP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# Deprecated
+
+⚠️ **This repository is no longer maintained.**
+
+Please use the [Secureframe hosted MCP server](https://mcp.secureframe.com/mcp_docs) instead.
+
+No new issues or pull requests will be accepted here.
+
+---
+
 # Secureframe MCP Server
 
 This [Model Context Protocol](https://modelcontextprotocol.io/) server provides read-only access to Secureframe's compliance automation platform for AI assistants like Claude and Cursor. Query security controls, monitor compliance tests, and access audit data across SOC 2, ISO 27001, CMMC, FedRAMP, and other frameworks.


### PR DESCRIPTION
The Secureframe MCP server is now offered as a hosted service. This repository is being archived — the README now directs users to the hosted MCP server documentation.